### PR TITLE
Add required Scryfall request headers to prevent 400 errors

### DIFF
--- a/source/scry_api.py
+++ b/source/scry_api.py
@@ -10,7 +10,7 @@ IS_FIRST_QUERY = True
 
 def get_api_url_from_query(query):
     # transform the query string into a url-friendly format, and attach it to the scryfall api url
-    api_url = 'https://api.scryfall.com/cards/search?q='
+    api_url = "https://api.scryfall.com/cards/search?q="
     return api_url + urllib.parse.quote_plus(query)
 
 
@@ -23,7 +23,14 @@ def get_api_data_from_url(url):
         IS_FIRST_QUERY = False
 
     try:
-        with urllib.request.urlopen(url) as response:
+        request = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "scry/1.0",
+                "Accept": "application/json",
+            },
+        )
+        with urllib.request.urlopen(request) as response:
             data = json.load(response)
     except urllib.error.HTTPError as exc:
         if exc.code == 404:

--- a/source/scry_api.py
+++ b/source/scry_api.py
@@ -10,7 +10,7 @@ IS_FIRST_QUERY = True
 
 def get_api_url_from_query(query):
     # transform the query string into a url-friendly format, and attach it to the scryfall api url
-    api_url = "https://api.scryfall.com/cards/search?q="
+    api_url = 'https://api.scryfall.com/cards/search?q='
     return api_url + urllib.parse.quote_plus(query)
 
 


### PR DESCRIPTION
## Summary
- Add explicit `User-Agent` and `Accept` headers to Scryfall API requests so `urllib` calls satisfy API requirements.
- Keep the existing query and pagination flow unchanged while preventing 400 `bad_request` responses.
- Rebuild the bundled `scry` executable so the distributed entrypoint includes the header fix.

## Testing
- `./scry --do-not-cache venser t:creature`